### PR TITLE
fix(oidc): providers order in map

### DIFF
--- a/modules/oidc/lambda/callback/index.js
+++ b/modules/oidc/lambda/callback/index.js
@@ -4,7 +4,8 @@ const https = require('https');
 const querystring = require('querystring');
 const crypto = require('crypto');
 
-const config = JSON.parse(process.env.OIDC_CONFIG_JSON || '{}');
+const configList = JSON.parse(process.env.OIDC_CONFIG_JSON || '[]');
+const config = Object.fromEntries(configList.map(cfg => [cfg.application_name, cfg]));
 
 exports.handler = (event, context, callback) => {
   //console.log('Callback Lambda - Received event:', JSON.stringify(event, null, 2));

--- a/modules/oidc/lambda/edge_auth/index.js
+++ b/modules/oidc/lambda/edge_auth/index.js
@@ -3,7 +3,9 @@
 const crypto = require('crypto');
 const querystring = require('querystring');
 
-const config = require('./config.json');
+// Load config as list and convert to map by application_name
+const configList = require('./config.json');
+const config = Object.fromEntries(configList.map(cfg => [cfg.application_name, cfg]));
 
 exports.handler = (event, context, callback) => {
   try {

--- a/modules/oidc/shared.tf
+++ b/modules/oidc/shared.tf
@@ -1,8 +1,9 @@
 locals {
   enabled = length(var.oidc) > 0
 
-  oidc_config = {
-    for cfg in var.oidc : cfg.application_name => {
+  oidc_config = [
+    for cfg in var.oidc : {
+      application_name     = cfg.application_name
       client_id            = cfg.application_id
       client_secret        = cfg.client_secret
       auth_url             = cfg.auth_url
@@ -12,13 +13,13 @@ locals {
       redirect_after_login = "https://${var.application_domain}"
       session_duration     = cfg.session_duration
     }
-  }
+  ]
 
   oidc_config_json = local.enabled ? jsonencode(local.oidc_config) : null
 }
 
 resource "random_string" "session_secret" {
-  count = local.enabled ? 1 : 0
+  count   = local.enabled ? 1 : 0
   length  = 64
   special = true
 }


### PR DESCRIPTION
move list to object conversion from terraform to nodejs lambdas to preserve order of the providers in the list, so the first provider defined is the default