### PR TITLE
Fix OIDC lambda - when using gitlab artifacts

### DIFF
--- a/modules/oidc/callback.tf
+++ b/modules/oidc/callback.tf
@@ -3,7 +3,7 @@ data "archive_file" "callback_lambda_zip" {
   count       = local.enabled ? 1 : 0
   type        = "zip"
   source_file = "${path.module}/lambda/callback/index.js"
-  output_path = "${path.module}/lambda/callback.zip"
+  output_path = var.callback_lambda_zip_path != null ? var.callback_lambda_zip_path : "${path.module}/lambda/callback.zip"
 }
 
 resource "aws_lambda_function" "oidc_callback" {

--- a/modules/oidc/edge.tf
+++ b/modules/oidc/edge.tf
@@ -2,7 +2,7 @@
 data "archive_file" "edge_lambda_zip" {
   count       = local.enabled ? 1 : 0
   type        = "zip"
-  output_path = "${path.module}/lambda/edge_auth.zip"
+  output_path = var.edge_lambda_zip_path != null ? var.edge_lambda_zip_path : "${path.module}/lambda/edge_auth.zip"
 
   source {
     filename = "index.js"

--- a/modules/oidc/variables.tf
+++ b/modules/oidc/variables.tf
@@ -27,6 +27,11 @@ variable "edge_lambda_zip_path" {
   default = null
 }
 
+variable "callback_lambda_zip_path" {
+  type    = string
+  default = null
+}
+
 variable "tags" {
   description = "Resources tags map"
   type        = map(string)

--- a/modules/oidc/variables.tf
+++ b/modules/oidc/variables.tf
@@ -22,6 +22,11 @@ variable "oidc" {
   default = []
 }
 
+variable "edge_lambda_zip_path" {
+  type    = string
+  default = null
+}
+
 variable "tags" {
   description = "Resources tags map"
   type        = map(string)

--- a/oidc.tf
+++ b/oidc.tf
@@ -9,5 +9,8 @@ module "oidc" {
   oidc               = var.oidc
   application_domain = local.main_domain
   project_name       = replace(local.main_domain_sanitized, ".", "-")
-  tags               = local.tags
+
+  edge_lambda_zip_path = var.edge_lambda_zip_path
+
+  tags = local.tags
 }

--- a/oidc.tf
+++ b/oidc.tf
@@ -10,7 +10,8 @@ module "oidc" {
   application_domain = local.main_domain
   project_name       = replace(local.main_domain_sanitized, ".", "-")
 
-  edge_lambda_zip_path = var.edge_lambda_zip_path
+  edge_lambda_zip_path     = var.edge_lambda_zip_path
+  callback_lambda_zip_path = var.callback_lambda_zip_path
 
   tags = local.tags
 }

--- a/oidc.tf
+++ b/oidc.tf
@@ -10,8 +10,8 @@ module "oidc" {
   application_domain = local.main_domain
   project_name       = replace(local.main_domain_sanitized, ".", "-")
 
-  edge_lambda_zip_path     = var.edge_lambda_zip_path
-  callback_lambda_zip_path = var.callback_lambda_zip_path
+  edge_lambda_zip_path     = var.oidc_edge_lambda_zip_path
+  callback_lambda_zip_path = var.oidc_callback_lambda_zip_path
 
   tags = local.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -270,3 +270,8 @@ variable "oidc" {
   }))
   default = []
 }
+
+variable "edge_lambda_zip_path" {
+  type    = string
+  default = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -275,3 +275,8 @@ variable "edge_lambda_zip_path" {
   type    = string
   default = null
 }
+
+variable "callback_lambda_zip_path" {
+  type    = string
+  default = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -271,12 +271,12 @@ variable "oidc" {
   default = []
 }
 
-variable "edge_lambda_zip_path" {
+variable "oidc_edge_lambda_zip_path" {
   type    = string
   default = null
 }
 
-variable "callback_lambda_zip_path" {
+variable "oidc_callback_lambda_zip_path" {
   type    = string
   default = null
 }


### PR DESCRIPTION
* put the lambdas .zip files out of module will avoid the artifacts deletion by modules init