### PR TITLE
feat(outputs): put deploy_role_name to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ module "static-site" {
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5, < 2.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.27 |
-| <a name="requirement_gitlab"></a> [gitlab](#requirement\_gitlab) | >= 15.7, < 19.0 |
+| <a name="requirement_gitlab"></a> [gitlab](#requirement\_gitlab) | >= 15.7, < 20.0 |
 
 ## Providers
 
@@ -75,6 +75,8 @@ module "static-site" {
 | [aws_cloudfront_origin_request_policy.managed_all_viewer_and_cloudfront_headers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_origin_request_policy) | data source |
 | [aws_iam_openid_connect_provider.gitlab](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_openid_connect_provider) | data source |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.assume_role_ec2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.assume_role_web_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.deploy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -87,12 +89,13 @@ module "static-site" {
 | ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_aws_env_vars_suffix"></a> [aws\_env\_vars\_suffix](#input\_aws\_env\_vars\_suffix) | Append suffix for Gitlab CI/CD environment variables if needed | `string` | `""` | no |
 | <a name="input_cloudfront_price_class"></a> [cloudfront\_price\_class](#input\_cloudfront\_price\_class) | CloudFront price class | `string` | `"PriceClass_100"` | no |
-| <a name="input_create_instance_profile"></a> [create\_instance\_profile](#input\_create\_instance\_profile) | Create instance profile for EC2 | `bool` | `false` | no |
+| <a name="input_create_instance_profile"></a> [create\_instance\_profile](#input\_create\_instance\_profile) | Create instance profile for EC2 and add ec2.amazonaws.com service trust to the deploy role's assume role policy. Requires enable\_deploy\_role = true. | `bool` | `false` | no |
 | <a name="input_custom_headers"></a> [custom\_headers](#input\_custom\_headers) | n/a | <pre>object({<br/>    headers = optional(map(object({<br/>      override = optional(bool, true)<br/>      value    = string<br/>    })))<br/>    cors_rules = optional(object({<br/>      use             = optional(bool, false)<br/>      allowed_headers = optional(list(string))<br/>      allowed_methods = optional(list(string))<br/>      allowed_origins = optional(list(string))<br/>      expose_headers  = optional(list(string))<br/>      max_age_seconds = optional(number)<br/>      override        = optional(bool, true)<br/>    }), null)<br/>    frame_options = optional(object({<br/>      use          = optional(bool, false)<br/>      frame_option = string<br/>      override     = optional(bool, true)<br/>    }), null)<br/>    referrer_policy = optional(object({<br/>      use             = optional(bool, false)<br/>      referrer_policy = string<br/>      override        = optional(bool, true)<br/>    }), null)<br/>    xss_protection = optional(object({<br/>      use        = optional(bool, false)<br/>      mode_block = bool<br/>      protection = bool<br/>      override   = optional(bool, true)<br/>    }), null)<br/>    content_security_policy = optional(object({<br/>      use      = optional(bool, false)<br/>      policy   = string<br/>      override = optional(bool, true)<br/>    }), null)<br/>    strict_transport_security = optional(object({<br/>      use                        = optional(bool, false)<br/>      access_control_max_age_sec = string<br/>      include_subdomains         = bool<br/>      preload                    = bool<br/>      override                   = optional(bool, true)<br/>    }), null)<br/>    content_type_options = optional(object({<br/>      override = optional(bool, true)<br/>    }), null)<br/>  })</pre> | `null` | no |
 | <a name="input_default_ttl"></a> [default\_ttl](#input\_default\_ttl) | Default amount of time that you want objects to stay in a CloudFront cache | `number` | `3600` | no |
+| <a name="input_deploy_pod_identity_role_arns"></a> [deploy\_pod\_identity\_role\_arns](#input\_deploy\_pod\_identity\_role\_arns) | List of IAM role ARNs granted S3 deploy access via bucket policy (for EKS pod identity CI runners). The roles must have matching IAM identity policies granting S3 and CloudFront actions. | `list(string)` | `[]` | no |
 | <a name="input_domain_zone_id"></a> [domain\_zone\_id](#input\_domain\_zone\_id) | The ID of the hosted zone for domain | `string` | n/a | yes |
 | <a name="input_domains"></a> [domains](#input\_domains) | List of domain aliases. You can also specify wildcard eg.: `*.example.com` | `list(string)` | n/a | yes |
-| <a name="input_enable_deploy_role"></a> [enable\_deploy\_role](#input\_enable\_deploy\_role) | Toggle IAM role creation for S3 deploy & CloudFront invalidation; This requires existing aws\_iam\_openid\_connect\_provider matching domain of your gitlab provider | `bool` | `false` | no |
+| <a name="input_enable_deploy_role"></a> [enable\_deploy\_role](#input\_enable\_deploy\_role) | Toggle IAM role creation for S3 deploy & CloudFront invalidation. Trust policy is assembled from two optional sources: GitLab OIDC web identity (when gitlab\_project\_ids/gitlab\_project\_id is set; requires existing aws\_iam\_openid\_connect\_provider matching the gitlab domain) and EC2 service trust (when create\_instance\_profile is true). | `bool` | `false` | no |
 | <a name="input_enable_deploy_user"></a> [enable\_deploy\_user](#input\_enable\_deploy\_user) | Toggle s3 deploy user creation | `bool` | `true` | no |
 | <a name="input_encrypt_with_kms"></a> [encrypt\_with\_kms](#input\_encrypt\_with\_kms) | Enable server side s3 bucket encryption with KMS key | `bool` | `false` | no |
 | <a name="input_extra_domains"></a> [extra\_domains](#input\_extra\_domains) | Map of extra\_domains with domain name and zone\_id | `map(string)` | `{}` | no |
@@ -108,6 +111,8 @@ module "static-site" {
 | <a name="input_max_ttl"></a> [max\_ttl](#input\_max\_ttl) | Maximum amount of time that you want objects to stay in a CloudFront cache | `number` | `86400` | no |
 | <a name="input_min_ttl"></a> [min\_ttl](#input\_min\_ttl) | Minimum amount of time that you want objects to stay in a CloudFront cache | `number` | `0` | no |
 | <a name="input_oidc"></a> [oidc](#input\_oidc) | List of OIDC providers | <pre>list(object({<br/>    application_name = string<br/>    application_id   = string<br/>    client_secret    = string<br/>    auth_url         = string<br/>    token_url        = string<br/>    session_druation = optional(number, 12 * 3600)<br/>  }))</pre> | `[]` | no |
+| <a name="input_oidc_callback_lambda_zip_path"></a> [oidc\_callback\_lambda\_zip\_path](#input\_oidc\_callback\_lambda\_zip\_path) | n/a | `string` | `null` | no |
+| <a name="input_oidc_edge_lambda_zip_path"></a> [oidc\_edge\_lambda\_zip\_path](#input\_oidc\_edge\_lambda\_zip\_path) | n/a | `string` | `null` | no |
 | <a name="input_origin_path"></a> [origin\_path](#input\_origin\_path) | Cloudfront origin path | `string` | `""` | no |
 | <a name="input_override_status_code_403"></a> [override\_status\_code\_403](#input\_override\_status\_code\_403) | Override status code for 403 error | `number` | `403` | no |
 | <a name="input_override_status_code_404"></a> [override\_status\_code\_404](#input\_override\_status\_code\_404) | Override status code for 404 error | `number` | `200` | no |
@@ -132,8 +137,9 @@ module "static-site" {
 | <a name="output_aws_s3_bucket_name"></a> [aws\_s3\_bucket\_name](#output\_aws\_s3\_bucket\_name) | n/a |
 | <a name="output_aws_s3_bucket_regional_domain_name"></a> [aws\_s3\_bucket\_regional\_domain\_name](#output\_aws\_s3\_bucket\_regional\_domain\_name) | n/a |
 | <a name="output_aws_secret_access_key"></a> [aws\_secret\_access\_key](#output\_aws\_secret\_access\_key) | n/a |
-| <a name="output_deploy_instance_profile"></a> [deploy\_instance\_profile](#output\_deploy\_instance\_profile) | n/a |
+| <a name="output_deploy_instance_profile_name"></a> [deploy\_instance\_profile\_name](#output\_deploy\_instance\_profile\_name) | n/a |
 | <a name="output_deploy_role_arn"></a> [deploy\_role\_arn](#output\_deploy\_role\_arn) | n/a |
+| <a name="output_deploy_role_name"></a> [deploy\_role\_name](#output\_deploy\_role\_name) | n/a |
 | <a name="output_oidc_callback_url"></a> [oidc\_callback\_url](#output\_oidc\_callback\_url) | n/a |
 | <a name="output_s3_kms_key_arn"></a> [s3\_kms\_key\_arn](#output\_s3\_kms\_key\_arn) | n/a |
 <!-- END_TF_DOCS -->

--- a/modules/gitlab/README.md
+++ b/modules/gitlab/README.md
@@ -9,13 +9,13 @@ This module will setup GitLab CI variables for static website deployment.
 | Name | Version |
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5, < 2.0 |
-| <a name="requirement_gitlab"></a> [gitlab](#requirement\_gitlab) | >= 15.7, < 19.0 |
+| <a name="requirement_gitlab"></a> [gitlab](#requirement\_gitlab) | >= 15.7, < 20.0 |
 
 ## Providers
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_gitlab"></a> [gitlab](#provider\_gitlab) | >= 15.7, < 19.0 |
+| <a name="provider_gitlab"></a> [gitlab](#provider\_gitlab) | >= 15.7, < 20.0 |
 
 ## Modules
 

--- a/modules/oidc/README.md
+++ b/modules/oidc/README.md
@@ -97,6 +97,8 @@ No modules.
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_application_domain"></a> [application\_domain](#input\_application\_domain) | Application domain for redirect after oidc login | `string` | n/a | yes |
+| <a name="input_callback_lambda_zip_path"></a> [callback\_lambda\_zip\_path](#input\_callback\_lambda\_zip\_path) | n/a | `string` | `null` | no |
+| <a name="input_edge_lambda_zip_path"></a> [edge\_lambda\_zip\_path](#input\_edge\_lambda\_zip\_path) | n/a | `string` | `null` | no |
 | <a name="input_oidc"></a> [oidc](#input\_oidc) | List of OIDC providers | <pre>list(object({<br/>    application_name = string<br/>    application_id   = string<br/>    client_secret    = string<br/>    auth_url         = string<br/>    token_url        = string<br/>    session_duration = optional(number, 12 * 3600)<br/>  }))</pre> | `[]` | no |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Prefix for naming the resources | `string` | `"static-site"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Resources tags map | `map(string)` | `{}` | no |

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,6 +19,10 @@ output "deploy_role_arn" {
   value = var.enable_deploy_role ? aws_iam_role.deploy[0].arn : null
 }
 
+output "deploy_role_name" {
+  value = var.enable_deploy_role ? aws_iam_role.deploy[0].id : null
+}
+
 output "deploy_instance_profile_name" {
   value = var.create_instance_profile ? aws_iam_instance_profile.deploy[0].name : null
 }


### PR DESCRIPTION
role name / id is more suitable for reading the role later via data outside of the module, we're keeping the deploy_role_arn output also as is.